### PR TITLE
manifest: remove experimental PWA entries

### DIFF
--- a/az/azmanifest.json
+++ b/az/azmanifest.json
@@ -6,38 +6,6 @@
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#000000",
-    "screenshots": [
-    {
-      "src": "https://bobkoto.github.io/bob-site/az/CubeTestPlaying1280x720.png",
-      "type": "image/png",
-      "sizes": "1280x720",
-      "form_factor" : "wide",
-      "label": "Intercept the spheres!"
-    },
-    {
-    "src": "https://bobkoto.github.io/bob-site/az/CubeTestPlaying800x600b.png",
-    "type": "image/png",
-    "sizes": "800x600",
-    "form_factor" : "narrow",
-    "label": "Intercept the spheres."
-    },
-    {
-      "src": "https://bobkoto.github.io/bob-site/az/CubeTestPlaying480x320.png",
-      "type": "image/png",
-      "sizes": "480x320",
-      "form_factor" : "wide",
-      "label": "Intercept the spheres.   wide"
-    },
-    {
-    "src": "https://bobkoto.github.io/bob-site/az/CubeTestPlaying480x320.png",
-    "type": "image/png",
-    "sizes": "480x320",
-    "form_factor" : "narrow",
-    "label": "Intercept the spheres. narrow"
-    }
-  ],
-    "description": "PWA Interception Arcade Game",
-    
       "icons": [
         {
           "src": "https://bobkoto.github.io/bob-site/az/intericon48.png",

--- a/az/index.html
+++ b/az/index.html
@@ -114,7 +114,7 @@
   <div>This game is Open Source and free to play and install as an offline web app.</div><br>
   <div id="message-container"></div>
    <!-- ***********************The Local VERSION to update*********************** --> 
-  <p> Local VER. b030 &nbsp;&nbsp; Time:  <span id="localTime"></span></div><br><br></p><br> <!-- Change the SW too!!!-->
+  <p> Local VER. b031 &nbsp;&nbsp; Time:  <span id="localTime"></span></div><br><br></p><br> <!-- Change the SW too!!!-->
   <!-- <h2>Local Time: <span id="localTime"></span></h2> -->
 
   <div>Local VERSION TEST  &nbsp;&nbsp; Time:  <span id="localTime"></span></div><br><br>

--- a/az/service-worker.js
+++ b/az/service-worker.js
@@ -1,5 +1,5 @@
 // Service Worker   in most cases be sure to edit VERSION to update/add cached content
-var VERSION = 'version_0b030';    //change index.html too!!! for now
+var VERSION = 'version_0b031';    //change index.html too!!! for now
 var GHPATH = '/bob-site/az';
 const CACHE_NAME = 'hello-pwa-cache-v146';
 var APP_PREFIX = 'hellopwa_';


### PR DESCRIPTION
only works on Chrome, not on Edge, Samsung, et. al. browsers