### PR TITLE
try explicitly setting viewport width = 400

### DIFF
--- a/aq/index.html
+++ b/aq/index.html
@@ -112,7 +112,7 @@
     <br><br><br>
     <div>This game is Open Source and free to play and install as an offline web app.</div><br>
         <!-- *****The Local VERSION to update***** -->
-    <p> Local VER. a016 &nbsp;&nbsp; Time:  <span id="localTime"></span></div><br><br></p><br> <!-- Change the SW too!!!-->
+    <p> Local VER. a017 &nbsp;&nbsp; Time:  <span id="localTime"></span></div><br><br></p><br> <!-- Change the SW too!!!-->
     <!--<div>Local VERSION TEST  &nbsp;&nbsp; Time:  <span id="localTime"></span></div><br><br>--> 
    
     <dialog id="about-dialog" class="dialogstyle"> <!--class="dialogstyle"> -->

--- a/aq/pinball01/index.html
+++ b/aq/pinball01/index.html
@@ -87,15 +87,22 @@
       // the canvas DOM size and WebGL render target sizes yourself.
       // config.matchWebGLToCanvasSize = false;
 
-      if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
-        // Mobile device style: fill the whole browser client area with the game canvas:
+        if (/iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
+          // Mobile device style: fill the whole browser client area with the game canvas:
 
-        var meta = document.createElement('meta');
-        meta.name = 'viewport';
-        meta.content = 'width=device-width, height=device-height, initial-scale=1.0, user-scalable=no, shrink-to-fit=yes';
-        document.getElementsByTagName('head')[0].appendChild(meta);
-        container.className = "unity-mobile";
-        canvas.className = "unity-mobile";
+          // Get the device width
+          const deviceWidth = window.innerWidth;
+
+          // Log the device width to the console
+          console.log('Device Width:', deviceWidth);
+
+
+          var meta = document.createElement('meta');
+          meta.name = 'viewport';
+          meta.content = 'width=400, height=device-height, initial-scale=1.0, user-scalable=no, shrink-to-fit=yes';
+          document.getElementsByTagName('head')[0].appendChild(meta);
+          container.className = "unity-mobile";
+          canvas.className = "unity-mobile";
 
         // To lower canvas resolution on mobile devices to gain some
         // performance, uncomment the following line:

--- a/aq/service-worker.js
+++ b/aq/service-worker.js
@@ -1,5 +1,5 @@
 // Service Worker   in most cases be sure to edit VERSION to update/add cached content
-var VERSION = 'version_0a016';    //change index.html too!!! for now
+var VERSION = 'version_0a017';    //change index.html too!!! for now
 var GHPATH = '/bob-site/aq';
 const CACHE_NAME = 'IPinballCache';
 var APP_PREFIX = 'ipball01appprefix_';


### PR DESCRIPTION
to override Unity Build setting of "device-width" which causes 'standalone' to exceed screen width and cut off content